### PR TITLE
On Windows platforms, get the HINSTANCE/HMODULE handle directly from …

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ raw-window-handle-0-6 = { package = "raw-window-handle", version = "0.6.0", opti
 objc2 = "0.5.1"
 
 [target.'cfg(target_os = "windows")'.dependencies]
-winapi = { version = "0.3", features = ["libloaderapi"] }
+winapi = { version = "0.3", features = ["libloaderapi", "winuser"] }
 
 [dependencies.glfw-sys]
 optional = true


### PR DESCRIPTION
…the HWND itself so that windows created by a seperate HMODULE can be handled. Add a thin wrapper type which implements RawDisplayHandle and RawWindowHandle but takes in a raw *mut GLFWwindow as well as the platform appropriate function pointer to get the window handle